### PR TITLE
Fix for very long filenames (255+ chars) on OS X (HFS+)

### DIFF
--- a/lib/download_pinboard.py
+++ b/lib/download_pinboard.py
@@ -97,7 +97,10 @@ class PinboardDownloader:
         self.set_last_updated()
 
     def _clean_filename(self, description):
-        return _SAVE_PATH + re.sub(r'[/]', ' ', description) + '.webloc'
+        cleaned_filename = re.sub(r'[/]', ' ', description)
+        if(len(cleaned_filename) > (248)):
+            cleaned_filename = cleaned_filename[0:248]
+        return _SAVE_PATH + cleaned_filename + '.webloc'
 
     def _get_pinboard_session(self, username, password, token):
         # todo: should maybe try attempting to connect a few times

--- a/lib/download_pinboard.py
+++ b/lib/download_pinboard.py
@@ -99,7 +99,7 @@ class PinboardDownloader:
     def _clean_filename(self, description):
         cleaned_filename = re.sub(r'[/]', ' ', description)
         if(len(cleaned_filename) > (248)):
-            cleaned_filename = cleaned_filename[0:248]
+            cleaned_filename = cleaned_filename[0:248].strip()
         return _SAVE_PATH + cleaned_filename + '.webloc'
 
     def _get_pinboard_session(self, username, password, token):

--- a/lib/download_pinboard.py
+++ b/lib/download_pinboard.py
@@ -97,6 +97,8 @@ class PinboardDownloader:
         self.set_last_updated()
 
     def _clean_filename(self, description):
+        # some filesystems HFS+) don't like very long filenames (255+ chars)
+        # stripping at 248 characters + .webloc prevents issues on those systems
         cleaned_filename = re.sub(r'[/]', ' ', description)
         if(len(cleaned_filename) > (248)):
             cleaned_filename = cleaned_filename[0:248].strip()


### PR DESCRIPTION
I ran into an issue with one particular bookmark that had a title of ~260 characters. Since filenames can't be larger than 255 characters (on HFS+, at least) I just wrote some quick code to cut it off at 248 (that's to leave room for the 7 characters that spell .webloc)